### PR TITLE
Review Sentiment & Summary Tool (Coursera: DeepLearning.AI & OpenAI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+﻿# Python / Jupyter
+.ipynb_checkpoints/
+__pycache__/
+*.pyc
+
+# OS
+.DS_Store
+
+# Secrets
+.env
+.env.*

--- a/review_sentiment_tool/README.md
+++ b/review_sentiment_tool/README.md
@@ -1,0 +1,27 @@
+﻿# Review Sentiment & Summary Tool
+
+This notebook turns short product reviews into:
+- **Sentiment** with a one-line rationale
+- **Summary** (1–2 factual lines)
+- **Rewrite** (clearer, neutral rephrasing)
+
+Built while taking *ChatGPT Prompt Engineering for Developers (DeepLearning.AI & OpenAI)*.
+
+## How to run
+1. Create a .env **next to the notebook** with:
+   \\\
+   OPENAI_API_KEY=sk-...
+   \\\
+2. Install deps:
+   \\\
+   pip install openai python-dotenv pandas
+   \\\
+3. Open the notebook and run cells top-to-bottom.
+
+> Note: .env is ignored by git via .gitignore.
+
+## What I practiced
+- Short, testable prompts
+- Safe key handling with python-dotenv
+- A tiny helper to call the OpenAI Responses API
+- Compact pandas table + optional CSV export

--- a/review_sentiment_tool/examples_for_readme.csv
+++ b/review_sentiment_tool/examples_for_readme.csv
@@ -1,0 +1,19 @@
+review,sentiment_json,summary,rewrite
+"The laptop is okay, but the battery dies in three hours and the screen is dim in sunlight.","```json
+{
+  ""sentiment"": ""Negative"",
+  ""rationale"": ""The text expresses dissatisfaction with the laptop's battery life and screen visibility.""
+}
+```",The laptop has a battery life of three hours and a screen that is difficult to see in sunlight.,"The laptop performs adequately; however, the battery lasts only three hours, and the screen tends to be dim in sunlight."
+Absolutely love this phone—camera quality is insane and the battery easily lasts two days!,"```json
+{
+  ""sentiment"": ""Positive"",
+  ""rationale"": ""The text expresses strong enthusiasm for the phone's features, highlighting both the camera quality and battery life positively.""
+}
+```",The phone has an excellent camera quality and a battery life of up to two days.,"I am very impressed with this phone; the camera quality is exceptional, and the battery provides performance that lasts up to two days."
+"Delivery was late. Product works as expected though, so it's fine.","```json
+{
+  ""sentiment"": ""Neutral"",
+  ""rationale"": ""While the delivery was late, the product functions as expected, balancing the negative and positive aspects.""
+}
+```","The product functions as expected, but the delivery was late.","The delivery was delayed; however, the product performs as expected, so overall, it is satisfactory."

--- a/review_sentiment_tool/review_sentiment_demo.ipynb
+++ b/review_sentiment_tool/review_sentiment_demo.ipynb
@@ -1,0 +1,398 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "927af8d0",
+   "metadata": {},
+   "source": [
+    "# Review Sentiment & Summary Tool\n",
+    "# Review Helper — Sentiment, Summary & Rewrite\n",
+    "\n",
+    "This notebook turns short reviews into something easier to work with:\n",
+    "- **Sentiment**: positive / neutral / negative (with a one-line rationale)\n",
+    "- **Summary**: a factual 1–2 line takeaway\n",
+    "- **Rewrite**: a clearer version of the original review\n",
+    "\n",
+    "**Why**: Teams often need to quickly scan user feedback to spot patterns. This helps reduce noise and standardize text for dashboards, triage, or further analysis.\n",
+    "\n",
+    "**How it could be used**:\n",
+    "- Auto-summarize new product reviews before sending to a support queue\n",
+    "- Clean up messy feedback before storing in a data warehouse\n",
+    "- Plug into a lightweight Streamlit app for non-technical users\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b78b0d8",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "We start with imports and API key setup. The API key should be stored securely as an environment variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7e5bcf7e-903d-4c68-952b-1ae23e597626",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ client ready\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Setup (short) ---\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "import os\n",
+    "\n",
+    "load_dotenv()  # reads the .env file next to this notebook\n",
+    "\n",
+    "api_key = (os.getenv(\"OPENAI_API_KEY\") or \"\").strip()\n",
+    "assert api_key, \"No OPENAI_API_KEY found. Did you create the .env file in THIS folder?\"\n",
+    "\n",
+    "client = OpenAI(api_key=api_key)\n",
+    "print(\"✅ client ready\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b22ea13d-9fd1-4bba-960a-8a36f5ebe894",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ .env loaded correctly\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Test that the env var is visible (does not print the key) ---\n",
+    "import os\n",
+    "assert os.getenv(\"OPENAI_API_KEY\"), \"No OPENAI_API_KEY found. Is your .env beside the notebook?\"\n",
+    "print(\"✅ .env loaded correctly\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fa05bb9b-c65d-4ca7-b878-1c5e5ea0bf71",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Model replied: Ready.\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    r = client.responses.create(\n",
+    "        model=\"gpt-4o-mini\",\n",
+    "        input=\"Say 'ready' in one word.\"\n",
+    "    )\n",
+    "    print(\"Model replied:\", r.output_text)\n",
+    "except Exception as e:\n",
+    "    # Show a readable error if auth fails\n",
+    "    import json, re\n",
+    "    msg = str(e)\n",
+    "    # Shorten the noise a little\n",
+    "    msg = re.sub(r\"\\s+\", \" \", msg).strip()\n",
+    "    print(\"Smoke test failed.\\n\", msg)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94f8a288",
+   "metadata": {},
+   "source": [
+    "## Prompt Setup\n",
+    "We define three simple prompts that are short, explicit, and testable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a64dd579",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Prompt Setup ---\n",
+    "\n",
+    "SENTIMENT_PROMPT = \"\"\"You are an analyst. Determine the sentiment of the text as one of:\n",
+    "Positive, Neutral, or Negative. Return JSON with fields: sentiment, rationale (one sentence).\n",
+    "Text: {review}\"\"\"\n",
+    "\n",
+    "SUMMARY_PROMPT = \"\"\"You are a helpful assistant. Summarize the core message of the review\n",
+    "in 1–2 concise lines. Avoid opinionated words. Focus on facts (battery life, build quality, etc.).\n",
+    "Text: {review}\"\"\"\n",
+    "\n",
+    "REWRITE_PROMPT = \"\"\"Rewrite the review to be clear, grammatical, and neutral in tone.\n",
+    "Keep 1 short paragraph. Keep product-specific details. Do not change the meaning.\n",
+    "Text: {review}\"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3d4f68d",
+   "metadata": {},
+   "source": [
+    "## Helper Function\n",
+    "We define a helper function to call the API in a consistent way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "77f8ece4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Helper Function ---\n",
+    "def call_llm(prompt: str, model: str = \"gpt-4o-mini\") -> str:\n",
+    "    try:\n",
+    "        resp = client.responses.create(model=model, input=prompt)\n",
+    "        return resp.output_text\n",
+    "    except Exception as e:\n",
+    "        return f\"Error: {e}\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47427263",
+   "metadata": {},
+   "source": [
+    "## Analyze Review Function\n",
+    "This function runs sentiment, summary, and rewrite for each review."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "bf963ab7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Analyze Review Function ---\n",
+    "from typing import Dict\n",
+    "\n",
+    "def analyze_review(review: str, model: str = \"gpt-4o-mini\") -> Dict[str, str]:\n",
+    "    sentiment_json = call_llm(SENTIMENT_PROMPT.format(review=review), model)\n",
+    "    summary       = call_llm(SUMMARY_PROMPT.format(review=review), model)\n",
+    "    rewrite       = call_llm(REWRITE_PROMPT.format(review=review), model)\n",
+    "    return {\n",
+    "        \"review\": review,\n",
+    "        \"sentiment_json\": sentiment_json,\n",
+    "        \"summary\": summary,\n",
+    "        \"rewrite\": rewrite,\n",
+    "    }\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14e738af",
+   "metadata": {},
+   "source": [
+    "## Sample Reviews\n",
+    "We’ll start with a few quick examples. You can replace these with your own dataset later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e13b3236",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Sample Reviews ---\n",
+    "sample_reviews = [\n",
+    "    \"The laptop is okay, but the battery dies in three hours and the screen is dim in sunlight.\",\n",
+    "    \"Absolutely love this phone—camera quality is insane and the battery easily lasts two days!\",\n",
+    "    \"Delivery was late. Product works as expected though, so it's fine.\"\n",
+    "]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "364b497f",
+   "metadata": {},
+   "source": [
+    "## Run the Tool\n",
+    "We now apply our function to the sample reviews."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "bef2b481",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>review</th>\n",
+       "      <th>sentiment_json</th>\n",
+       "      <th>summary</th>\n",
+       "      <th>rewrite</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>The laptop is okay, but the battery dies in three hours and the screen is di...</td>\n",
+       "      <td>```json\\n{\\n  \"sentiment\": \"Negative\",\\n  \"rationale\": \"The text conveys dis...</td>\n",
+       "      <td>The laptop has a battery life of three hours and the screen visibility is po...</td>\n",
+       "      <td>The laptop functions adequately, but the battery life is limited to three ho...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Absolutely love this phone—camera quality is insane and the battery easily l...</td>\n",
+       "      <td>```json\\n{\\n  \"sentiment\": \"Positive\",\\n  \"rationale\": \"The text expresses s...</td>\n",
+       "      <td>The phone features excellent camera quality and a battery life of up to two ...</td>\n",
+       "      <td>I am very impressed with this phone; the camera quality is excellent, and th...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Delivery was late. Product works as expected though, so it's fine.</td>\n",
+       "      <td>```json\\n{\\n  \"sentiment\": \"Neutral\",\\n  \"rationale\": \"While the delivery wa...</td>\n",
+       "      <td>The product functions as intended, but delivery was delayed.</td>\n",
+       "      <td>The delivery was delayed; however, the product functions as expected, so ove...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                            review  \\\n",
+       "0  The laptop is okay, but the battery dies in three hours and the screen is di...   \n",
+       "1  Absolutely love this phone—camera quality is insane and the battery easily l...   \n",
+       "2               Delivery was late. Product works as expected though, so it's fine.   \n",
+       "\n",
+       "                                                                    sentiment_json  \\\n",
+       "0  ```json\\n{\\n  \"sentiment\": \"Negative\",\\n  \"rationale\": \"The text conveys dis...   \n",
+       "1  ```json\\n{\\n  \"sentiment\": \"Positive\",\\n  \"rationale\": \"The text expresses s...   \n",
+       "2  ```json\\n{\\n  \"sentiment\": \"Neutral\",\\n  \"rationale\": \"While the delivery wa...   \n",
+       "\n",
+       "                                                                           summary  \\\n",
+       "0  The laptop has a battery life of three hours and the screen visibility is po...   \n",
+       "1  The phone features excellent camera quality and a battery life of up to two ...   \n",
+       "2                     The product functions as intended, but delivery was delayed.   \n",
+       "\n",
+       "                                                                           rewrite  \n",
+       "0  The laptop functions adequately, but the battery life is limited to three ho...  \n",
+       "1  I am very impressed with this phone; the camera quality is excellent, and th...  \n",
+       "2  The delivery was delayed; however, the product functions as expected, so ove...  "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# --- Run the Tool ---\n",
+    "import pandas as pd\n",
+    "pd.set_option(\"display.max_colwidth\", 80)  # keeps the table compact for screenshots\n",
+    "\n",
+    "results = [analyze_review(r) for r in sample_reviews]\n",
+    "df = pd.DataFrame(results, columns=[\"review\", \"sentiment_json\", \"summary\", \"rewrite\"])\n",
+    "df.head(3)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43532e23",
+   "metadata": {},
+   "source": [
+    "## Findings\n",
+    "The sentiment analysis works well and gives structured JSON that’s easy to work with.\n",
+    "\n",
+    "Summaries stay short and to the point, focusing on the main facts instead of opinions.\n",
+    "\n",
+    "The rewrite step makes reviews clearer and more readable without changing the meaning.\n",
+    "\n",
+    "The tool runs quickly with gpt-4o-mini, and switching to a stronger model like gpt-4.1 could improve accuracy on harder cases.\n",
+    "\n",
+    "It handles normal reviews smoothly, but it would be worth testing trickier cases like sarcasm, mixed opinions, or emotional wording to see how robust it is."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f269ebdc",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "Some ways to expand this project:\n",
+    "- Run the tool on a larger dataset of reviews (CSV or scraped data).\n",
+    "- Add evaluation metrics to compare summaries against ground truth.\n",
+    "- Fine-tune prompt wording for more consistency.\n",
+    "- Integrate into a web app with Streamlit or Flask."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fa259ad-1dcc-49b8-a627-362d165e35fd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90065a2a-16b8-47ea-b178-8e716c4e51e1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This adds a small notebook project that turns short product reviews into:

Sentiment (positive/neutral/negative) with a one-line rationale

Summary (1–2 factual lines)

Rewrite (clearer, neutral rephrasing)

Built while taking ChatGPT Prompt Engineering for Developers (DeepLearning.AI & OpenAI).
Includes a compact pandas table view and an optional CSV export for sharing.

How to run

Create a .env next to the notebook with OPENAI_API_KEY=sk-…

pip install openai python-dotenv pandas

Open the notebook and run top → bottom.